### PR TITLE
Improve missing dependency message

### DIFF
--- a/src/mcp_scan/MCPScanner.py
+++ b/src/mcp_scan/MCPScanner.py
@@ -1,13 +1,16 @@
 import os
-from pydoc import describe
-from re import A
 import traceback
-from mcp import ClientSession, StdioServerParameters, types
-from mcp.client.stdio import stdio_client
-from mcp.client.sse import sse_client
-from mcp.types import Implementation as MCPClientImplementation
+try:
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+    from mcp.client.sse import sse_client
+    from mcp.types import Implementation as MCPClientImplementation
+except ImportError as e:  # pragma: no cover - runtime dependency check
+    raise ImportError(
+        "The 'mcp' package is required for MCP-Scan. "
+        "Install it with 'pip install mcp[cli]' to enable scanning."
+    ) from e
 import json
-import os
 import textwrap
 import asyncio
 import requests


### PR DESCRIPTION
## Summary
- handle missing `mcp` dependency at import time with a clearer error message

## Testing
- `python -m pip install -e .` *(fails: Could not fetch build dependencies)*